### PR TITLE
300030

### DIFF
--- a/signinlog-results.txt
+++ b/signinlog-results.txt
@@ -707,7 +707,7 @@ Error Code|||||Message|||||Remediation
 293002|||||Proof-of-possesion validation failed.|||||No Remediation Provided
 293003|||||RDP protocol is not supported for the requested client or resource application.|||||No Remediation Provided
 293004|||||The target-device identifier in the request {targetDeviceId} was not found in the tenant {tenantId}.|||||No Remediation Provided
-300030||||| ¿¿Extranet Lockout Error??
+300030||||| ¿¿Extranet Lock Out Error??
 392100|||||Unable to locate a user using the provided user information.|||||No Remediation Provided
 392101|||||User has not set up remote sign-in with the Authenticator app.|||||No Remediation Provided
 392102|||||The session tracking token has expired.|||||No Remediation Provided

--- a/signinlog-results.txt
+++ b/signinlog-results.txt
@@ -707,6 +707,7 @@ Error Code|||||Message|||||Remediation
 293002|||||Proof-of-possesion validation failed.|||||No Remediation Provided
 293003|||||RDP protocol is not supported for the requested client or resource application.|||||No Remediation Provided
 293004|||||The target-device identifier in the request {targetDeviceId} was not found in the tenant {tenantId}.|||||No Remediation Provided
+300030||||| ¿¿Extranet Lockout Error??
 392100|||||Unable to locate a user using the provided user information.|||||No Remediation Provided
 392101|||||User has not set up remote sign-in with the Authenticator app.|||||No Remediation Provided
 392102|||||The session tracking token has expired.|||||No Remediation Provided


### PR DESCRIPTION
I have observed this error from ADFSSignInLogs. It is not present in https://login.microsoftonline.com/error

Microsoft might refer to it as Extranet Lock Out Error (https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-health-adfs-risky-ip-workbook)

In the docs is firstly written wrong (as 30030)

![image](https://user-images.githubusercontent.com/2527990/154441975-5d155a81-ae55-4687-9c34-00579b2a9543.png)

Below in a query is written right (as 300030).

![image](https://user-images.githubusercontent.com/2527990/154442176-0524af4f-abd3-4b2d-a05f-1803282360d5.png)

I can confirm this activity originates from the extranet.

Please, modify the description as you wish.